### PR TITLE
Workaround para conseguir capturar todos os grupos

### DIFF
--- a/functions/Venom/groups.js
+++ b/functions/Venom/groups.js
@@ -17,10 +17,10 @@ export default class Group {
       let data = Sessions.getSession(req.body.session)
       const response = await data.client.getAllChats();
       let groups = response.filter(function (data) {
-        return data.isGroup
+        return data?.isGroup
       })
       groups = groups.map(data => {
-        return { 'id': data.id.user, 'name': data.name }
+        return { 'id': data?.id?.user, 'name': data?.name }
       })
       return res.status(200).json({
         "result": 200,

--- a/functions/Venom/groups.js
+++ b/functions/Venom/groups.js
@@ -15,12 +15,12 @@ export default class Group {
   static async getAllGroups(req, res) {
     try {
       let data = Sessions.getSession(req.body.session)
-      const response = await data.client.getAllGroups();
-      let groups = response.map(function (data) {
-        return {
-          'id': data.id.user,
-          'name': data.name,
-        }
+      const response = await data.client.getAllChats();
+      let groups = response.filter(function (data) {
+        return data.isGroup
+      })
+      groups = groups.map(data => {
+        return { 'id': data.id.user, 'name': data.name }
       })
       return res.status(200).json({
         "result": 200,


### PR DESCRIPTION
No Venom as funções getAllGroups() e getAllChatsGroups() não funcionam, por isso o único jeito no momento de conseguir retornar todos os grupos é esse.