### PR TITLE
**Implementando envio de mensagens para gupos**

### DIFF
--- a/functions/Venom/mensagens.js
+++ b/functions/Venom/mensagens.js
@@ -16,7 +16,9 @@ export default class Mensagens {
 
     static async sendText(req, res) {
         let data = Sessions.getSession(req.body.session)
-        let number = req.body.number + '@c.us';
+        let isGroup = req.body.isGroup;
+        let number = isGroup === true ? req.body.number + '@g.us' : req.body.number + '@c.us';
+
         if (!req.body.text) {
             return res.status(400).json({
                 status: 400,
@@ -222,6 +224,7 @@ export default class Mensagens {
             })
         }
     }
+
     static async sendFile64(req, res) {
         if (!req.body.path) {
             return res.status(400).send({
@@ -338,7 +341,6 @@ export default class Mensagens {
         }
     }
 
-
     static async sendVoiceBase64(req, res) {
         let data = Sessions.getSession(req.body.session)
         let number = req.body.number;
@@ -378,7 +380,9 @@ export default class Mensagens {
     static async sendLink(req, res) {
         let data = Sessions.getSession(req.body.session)
         let isURL = await urlExists(req.body.url);
-        let number = req.body.number + '@c.us';
+        let isGroup = req.body.isGroup;
+        let number = isGroup === true ? req.body.number + '@g.us' : req.body.number + '@c.us';
+
         if (!req.body.url) {
             return res.status(400).json({
                 status: 400,

--- a/functions/WPPConnect/mensagens.js
+++ b/functions/WPPConnect/mensagens.js
@@ -16,7 +16,9 @@ export default class Mensagens {
 
     static async sendText(req, res) {
         let data = Sessions.getSession(req.body.session)
-        let number = req.body.number + '@c.us';
+        let isGroup = req.body.isGroup;
+        let number = isGroup === true ? req.body.number + '@g.us' : req.body.number + '@c.us';
+
         if (!req.body.text) {
             return res.status(400).json({
                 status: 400,
@@ -375,7 +377,9 @@ export default class Mensagens {
     static async sendLink(req, res) {
         let data = Sessions.getSession(req.body.session)
         let isURL = await urlExists(req.body.url);
-        let number = req.body.number + '@c.us';
+        let isGroup = req.body.isGroup;
+        let number = isGroup === true ? req.body.number + '@g.us' : req.body.number + '@c.us';
+        
         if (!req.body.url) {
             return res.status(400).json({
                 status: 400,

--- a/functions/WhatsappWebJS/mensagens.js
+++ b/functions/WhatsappWebJS/mensagens.js
@@ -29,6 +29,9 @@ export default class Mensagens {
     static async sendText(req, res) {
         let { session, number, text } = req.body
         let data = Sessions.getSession(session)
+        let isGroup = req.body.isGroup;
+        number = isGroup === true ? req.body.number + '@g.us' : req.body.number + '@c.us';
+
         if (!req.body.text) {
             return res.status(400).json({
                 status: 400,
@@ -37,7 +40,7 @@ export default class Mensagens {
         }
         else {
             try {
-                let response = await data.client.sendMessage(number + '@c.us', text)
+                let response = await data.client.sendMessage(number, text)
                 return res.status(200).json({
                     result: 200,
                     type: 'text',
@@ -478,7 +481,9 @@ export default class Mensagens {
 
     static async sendLink(req, res) {
         let data = Sessions.getSession(req.body.session)
-        let number = req.body.number + '@c.us';
+        let isGroup = req.body.isGroup;
+        let number = isGroup === true ? req.body.number + '@g.us' : req.body.number + '@c.us';
+        
         if (!req.body.url) {
             return res.status(400).json({
                 status: 400,

--- a/middlewares/checkNumber.js
+++ b/middlewares/checkNumber.js
@@ -13,39 +13,45 @@ const checkNumber = async (req, res, next) => {
     let session = req.body.session
     let data = Sessions.getSession(session)
 
-    if (config.engine === '1') {
-        if (!number) {
-            return res.status(401).send({ message: "Telefone não informado." });
-        }
-        else {
-            let profile = await data?.client?.isRegisteredUser(`${req?.body?.number}c`)
-            if (!profile) {
-                return res.status(400).json({
-                    response: false,
-                    status: "error",
-                    message: 'O telefone informado nao esta registrado no whatsapp.'
-                })
-            } else {
-                next();
+    let isGroup = req.body.isGroup
+    if (isGroup === true) {
+        next();
+    }
+    else {
+        if (config.engine === '1') {
+            if (!number) {
+                return res.status(401).send({ message: "Telefone não informado." });
             }
-        }
-    } else {
-        if (!number) {
-            return res.status(401).send({ message: "Telefone não informado." });
-        }
-        else {
-            let profile = await data.client.checkNumberStatus(req.body.number + c)
-            if (!profile.numberExists) {
-                return res.status(400).json({
-                    response: false,
-                    status: "error",
-                    message: 'O telefone informado nao esta registrado no whatsapp.'
-                })
-            } else {
-                next();
+            else {
+                let profile = await data?.client?.isRegisteredUser(`${req?.body?.number}c`)
+                if (!profile) {
+                    return res.status(400).json({
+                        response: false,
+                        status: "error",
+                        message: 'O telefone informado nao esta registrado no whatsapp.'
+                    })
+                } else {
+                    next();
+                }
+            }
+        } else {
+            if (!number) {
+                return res.status(401).send({ message: "Telefone não informado." });
+            }
+            else {
+                let profile = await data.client.checkNumberStatus(req.body.number + c)
+                if (!profile.numberExists) {
+                    return res.status(400).json({
+                        response: false,
+                        status: "error",
+                        message: 'O telefone informado nao esta registrado no whatsapp.'
+                    })
+                } else {
+                    next();
+                }
             }
         }
     }
 }
 
-export  { checkNumber }
+export { checkNumber }


### PR DESCRIPTION
O envio de mensagem para grupos foi implementado para as 3 engines, para os seguintes métodos:
1. SendText
2. SendLink

Para fazer uso, é necessário incluir o parâmetro ( "isGroup": true ) no request. Caso não inclua, a API entenderá que é um contato.